### PR TITLE
Add simple web UI for heap analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,12 @@
   "dependencies": {
     "@types/node": "^24.1.0",
     "commander": "^14.0.0",
+    "express": "^4.19.2",
     "heapsnapshot-parser": "^0.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { analyzeSnapshot } from './analyzer';
 import { compareSnapshots } from './comparer';
 import { writeAnalysis, writeComparison } from './reporter';
+import { startServer } from './server';
 
 program
   .name('heapdump-analyzer')
@@ -28,6 +29,15 @@ program
     const baseName = path.basename(newSnapshot, path.extname(newSnapshot)) + '-diff';
     writeComparison(comparison, path.join('output'), baseName);
     console.log('Comparison written for snapshots');
+  });
+
+program
+  .command('serve <analysisJson>')
+  .description('Serve web UI for an analysis JSON file')
+  .option('-p, --port <port>', 'Port to run the server on', '3000')
+  .action((analysisJson, options) => {
+    const port = parseInt(options.port, 10);
+    startServer(analysisJson, port);
   });
 
 program.parse();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import fs from 'fs';
+import { AnalysisResult } from './analyzer';
+
+export function startServer(jsonPath: string, port: number = 3000) {
+  const app = express();
+
+  app.get('/data', (_req, res) => {
+    const data: AnalysisResult = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+    res.json(data);
+  });
+
+  app.get('/', (_req, res) => {
+    res.send(`<!doctype html>
+<html>
+<head>
+  <title>Heap Analysis</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <h1>Top Nodes</h1>
+  <canvas id="chart"></canvas>
+  <script>
+    fetch('/data').then(r => r.json()).then(data => {
+      const ctx = document.getElementById('chart').getContext('2d');
+      const labels = data.topNodes.map(n => n.name);
+      const sizes = data.topNodes.map(n => n.self_size);
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Self Size',
+            data: sizes,
+            backgroundColor: 'rgba(75, 192, 192, 0.5)'
+          }]
+        }
+      });
+    });
+  </script>
+</body>
+</html>`);
+  });
+
+  app.listen(port, () => {
+    console.log(`Server running at http://localhost:${port}`);
+  });
+}


### PR DESCRIPTION
## Summary
- add express server for analysis charts
- support `serve` command in CLI
- include express packages

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880d70c05008325a93c79dc67e33425