### PR TITLE
Compute retained size with dominator tree traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ heapdump-analyzer --compare dumps/heap-123.heapsnapshot dumps/heap-456.heapsnaps
 - Export to flamegraph-compatible format
 
 ## Notes
-- The tool does **not** compute `retainedSize` unless dominator tree traversal is implemented.
+- The tool computes `retainedSize` using a dominator tree traversal.
 - Will document the blocking nature of `v8.getHeapSnapshot()` for snapshot producers.
 
 ## Target Users

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -2,10 +2,99 @@ import fs from 'fs';
 import { parse } from 'heapsnapshot-parser';
 import { HEAVY_CLOSURE_THRESHOLD, LARGE_ARRAY_THRESHOLD } from '../config';
 
+const RETAINED_SIZE_EDGE_TYPES = new Set(['context', 'element', 'property', 'hidden']);
+
+function computeRetainedSizes(nodes: any[]): number[] {
+  const rootIndex = nodes.findIndex((n: any) => n.type === 'synthetic' && n.name === '(GC roots)');
+  const root = rootIndex !== -1 ? rootIndex : 0;
+
+  const preds: number[][] = Array.from({ length: nodes.length }, () => []);
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    if (!node || !node.references) continue;
+    for (const ref of node.references) {
+      if (ref.toNodeIndex == null) continue;
+      if (RETAINED_SIZE_EDGE_TYPES.has(ref.type)) {
+        preds[ref.toNodeIndex].push(i);
+      }
+    }
+  }
+
+  const idom: number[] = new Array(nodes.length).fill(-1);
+  idom[root] = root;
+
+  const order: number[] = [];
+  const visited = new Array(nodes.length).fill(false);
+  (function dfs(idx: number) {
+    visited[idx] = true;
+    const node = nodes[idx];
+    if (node && node.references) {
+      for (const ref of node.references) {
+        if (RETAINED_SIZE_EDGE_TYPES.has(ref.type) && !visited[ref.toNodeIndex]) {
+          dfs(ref.toNodeIndex);
+        }
+      }
+    }
+    order.push(idx);
+  })(root);
+
+  const rpo = order.reverse();
+
+  const intersect = (b1: number, b2: number): number => {
+    let finger1 = b1;
+    let finger2 = b2;
+    while (finger1 !== finger2) {
+      while (finger1 > finger2) finger1 = idom[finger1];
+      while (finger2 > finger1) finger2 = idom[finger2];
+    }
+    return finger1;
+  };
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const n of rpo) {
+      if (n === root) continue;
+      let newIdom: number | null = null;
+      for (const p of preds[n]) {
+        if (idom[p] !== -1) {
+          newIdom = newIdom === null ? p : intersect(p, newIdom);
+        }
+      }
+      if (newIdom !== null && idom[n] !== newIdom) {
+        idom[n] = newIdom;
+        changed = true;
+      }
+    }
+  }
+
+  const children: number[][] = Array.from({ length: nodes.length }, () => []);
+  for (let i = 0; i < idom.length; i++) {
+    const dom = idom[i];
+    if (i !== root && dom !== -1) {
+      children[dom].push(i);
+    }
+  }
+
+  const retained: number[] = new Array(nodes.length).fill(0);
+  const calc = (idx: number): number => {
+    let size = nodes[idx].self_size || 0;
+    for (const c of children[idx]) {
+      size += calc(c);
+    }
+    retained[idx] = size;
+    return size;
+  };
+  calc(root);
+
+  return retained;
+}
+
 export interface AnalysisNode {
   name: string;
   type: string;
   self_size: number;
+  retained_size?: number;
 }
 
 export interface AnalysisResult {
@@ -20,6 +109,11 @@ export function analyzeSnapshot(snapshotPath: string): AnalysisResult {
   const snapshotData = fs.readFileSync(snapshotPath, 'utf8');
   const snapshot = parse(snapshotData) as any;
   const nodes: any[] = snapshot.nodes || [];
+  for (let i = 0; i < nodes.length; i++) {
+    nodes[i].index = i;
+  }
+
+  const retainedSizes = computeRetainedSizes(nodes);
 
   let totalSize = 0;
   for (const n of nodes) {
@@ -30,16 +124,27 @@ export function analyzeSnapshot(snapshotPath: string): AnalysisResult {
   const topNodes = sorted.slice(0, 10).map(n => ({
     name: n.name,
     type: n.type,
-    self_size: n.self_size
+    self_size: n.self_size,
+    retained_size: retainedSizes[n.index]
   }));
 
   const heavyClosures = nodes
     .filter(n => n.type === 'Closure' && n.self_size > HEAVY_CLOSURE_THRESHOLD)
-    .map(n => ({ name: n.name, type: n.type, self_size: n.self_size }));
+    .map(n => ({
+      name: n.name,
+      type: n.type,
+      self_size: n.self_size,
+      retained_size: retainedSizes[n.index]
+    }));
 
   const largeArrays = nodes
     .filter(n => /Array|Buffer/.test(n.type) && n.self_size > LARGE_ARRAY_THRESHOLD)
-    .map(n => ({ name: n.name, type: n.type, self_size: n.self_size }));
+    .map(n => ({
+      name: n.name,
+      type: n.type,
+      self_size: n.self_size,
+      retained_size: retainedSizes[n.index]
+    }));
 
   return {
     totalSize,

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -13,18 +13,21 @@ export function writeAnalysis(result: AnalysisResult, outDir: string, baseName: 
   textLines.push(`Node Count: ${result.nodeCount}`);
   textLines.push('Top Nodes:');
   for (const n of result.topNodes) {
-    textLines.push(`  ${n.type} ${n.name} - ${formatBytes(n.self_size)}`);
+    const rs = n.retained_size ? ` (retained ${formatBytes(n.retained_size)})` : '';
+    textLines.push(`  ${n.type} ${n.name} - ${formatBytes(n.self_size)}${rs}`);
   }
   if (result.heavyClosures.length) {
     textLines.push('Heavy Closures:');
     for (const n of result.heavyClosures) {
-      textLines.push(`  ${n.name} - ${formatBytes(n.self_size)}`);
+      const rs = n.retained_size ? ` (retained ${formatBytes(n.retained_size)})` : '';
+      textLines.push(`  ${n.name} - ${formatBytes(n.self_size)}${rs}`);
     }
   }
   if (result.largeArrays.length) {
     textLines.push('Large Arrays/Buffers:');
     for (const n of result.largeArrays) {
-      textLines.push(`  ${n.type} ${n.name} - ${formatBytes(n.self_size)}`);
+      const rs = n.retained_size ? ` (retained ${formatBytes(n.retained_size)})` : '';
+      textLines.push(`  ${n.type} ${n.name} - ${formatBytes(n.self_size)}${rs}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- add dominator tree traversal to compute retained size for nodes
- expose retained sizes in analysis output
- show retained size information in text reports
- update README notes

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6880d81525608325bcfd03301dad1fbe